### PR TITLE
更新・削除イベントの追加

### DIFF
--- a/app/inventory/products/page.tsx
+++ b/app/inventory/products/page.tsx
@@ -20,18 +20,31 @@ export default function Page() {
 
   // 新規登録処理、新規登録行の表示状態を保持
   const [shownNewRow, setShownNewRow] = useState(false);
-  const handleShowNewRow = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
+  const handleShowNewRow = () => {
     setShownNewRow(true);
   };
-  const handleAddCancel = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
+  const handleAddCancel = () => {
     setShownNewRow(false);
   };
-  const handleAdd = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    // バックエンドを使用した登録処理を呼ぶ
+  const handleAdd = () => {
+    // TODO: バックエンドを使用した登録処理を呼ぶ
     setShownNewRow(false);
+  };
+
+  // 更新・削除処理、更新・削除行の表示状態を保持
+  const [editingRow, setEditingRow] = useState(0);
+  const handleEditRow = (id: number) => {
+    setShownNewRow(false);
+    setEditingRow(id);
+  };
+  const handleEditCancel = (id: number) => {
+    setEditingRow(0);
+  };
+  const handleEdit = (id: number) => {
+    setEditingRow(0);
+  };
+  const handleDelete = (id: number) => {
+    setEditingRow(0);
   };
 
   return (
@@ -77,20 +90,52 @@ export default function Page() {
           ) : (
             ""
           )}
-          {data.map((data: ProductData) => (
-            <tr key={data.id}>
-              <td>{data.id}</td>
-              <td>{data.name}</td>
-              <td>{data.price}</td>
-              <td>{data.description}</td>
-              <td>
-                <Link href={`/inventory/products/${data.id}`}>在庫処理</Link>
-              </td>
-              <td>
-                <button type="button">更新・削除</button>
-              </td>
-            </tr>
-          ))}
+          {data.map((data: ProductData) =>
+            editingRow === data.id ? (
+              <tr key={data.id}>
+                <td>{data.id}</td>
+                <td>
+                  <input type="text" defaultValue={data.name} />
+                </td>
+                <td>
+                  <input type="number" defaultValue={data.price} />
+                </td>
+                <td>
+                  <input type="text" defaultValue={data.description} />
+                </td>
+                <td />
+                <td>
+                  <button
+                    type="button"
+                    onClick={() => handleEditCancel(data.id)}
+                  >
+                    キャンセル
+                  </button>
+                  <button type="button" onClick={() => handleEdit(data.id)}>
+                    更新する
+                  </button>
+                  <button type="button" onClick={() => handleDelete(data.id)}>
+                    削除する
+                  </button>
+                </td>
+              </tr>
+            ) : (
+              <tr key={data.id}>
+                <td>{data.id}</td>
+                <td>{data.name}</td>
+                <td>{data.price}</td>
+                <td>{data.description}</td>
+                <td>
+                  <Link href={`/inventory/products/${data.id}`}>在庫処理</Link>
+                </td>
+                <td>
+                  <button type="button" onClick={() => handleEditRow(data.id)}>
+                    更新・削除
+                  </button>
+                </td>
+              </tr>
+            ),
+          )}
         </tbody>
       </table>
     </>

--- a/app/inventory/products/page.tsx
+++ b/app/inventory/products/page.tsx
@@ -32,19 +32,19 @@ export default function Page() {
   };
 
   // 更新・削除処理、更新・削除行の表示状態を保持
-  const [editingRow, setEditingRow] = useState(0);
+  const [editingRow, setEditingRow] = useState<number | null>(null);
   const handleEditRow = (id: number) => {
     setShownNewRow(false);
     setEditingRow(id);
   };
   const handleEditCancel = (id: number) => {
-    setEditingRow(0);
+    setEditingRow(null);
   };
   const handleEdit = (id: number) => {
-    setEditingRow(0);
+    setEditingRow(null);
   };
   const handleDelete = (id: number) => {
-    setEditingRow(0);
+    setEditingRow(null);
   };
 
   return (


### PR DESCRIPTION
このプルリクエストは、在庫管理ページにおける製品エントリーの編集および削除機能を追加します。また、`event.preventDefault()` の使用を削除することで、イベントハンドラ関数を簡素化します。

### 新機能:

  * 製品エントリーの編集および削除を可能にするため、編集中の行のステート管理を `editingRow` と、それに対応するハンドラ関数 (`handleEditRow`, `handleEditCancel`, `handleEdit`, `handleDelete`) を追加しました。（`app/inventory/products/page.tsx`, [[app/inventory/products/page.tsxL23-R49](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L23-R49)](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L23-R49))

  * 行が編集モードの場合に、入力フィールドとアクションボタン（キャンセル、更新、削除）を表示するように、製品リストのレンダリングロジックを更新しました。（`app/inventory/products/page.tsx`, [[app/inventory/products/page.tsxL80-R122](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L80-R122)](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L80-R122))

### 簡素化:

  * イベントハンドリングロジックを簡素化するため、`handleShowNewRow`、`handleAddCancel`、および `handleAdd` 関数から `event.preventDefault()` を削除しました。（`app/inventory/products/page.tsx`, [[app/inventory/products/page.tsxL23-R49](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L23-R49)](https://www.google.com/search?q=diffhunk://%23diff-483369fc6149ae8fda7f496fa9a4c6e0f12a2f1e415e0ec011518d4919493f74L23-R49))