### PR TITLE
動的ルートのパラメーターの取得

### DIFF
--- a/app/inventory/products/[id]/page.tsx
+++ b/app/inventory/products/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { use, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import inventoriesData from "../sample/dummy_inventories.json";
 import productsData from "../sample/dummy_products.json";
 type ProductData = {
@@ -20,9 +21,9 @@ type InventoryData = {
   inventory: number;
 };
 
-export default function Page({ params }: { params: Promise<{ id: string }> }) {
-  // paramsをアンラップ(展開)
-  const id = Number(use(params).id);
+export default function Page() {
+  const params = useParams<{ id: string }>();
+  const id = Number(params?.id);
 
   // 読込データを保持
   const [product, setProduct] = useState<ProductData>({

--- a/app/inventory/products/[id]/page.tsx
+++ b/app/inventory/products/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { use, useEffect, useState } from "react";
 import inventoriesData from "../sample/dummy_inventories.json";
 import productsData from "../sample/dummy_products.json";
 type ProductData = {
@@ -20,9 +20,9 @@ type InventoryData = {
   inventory: number;
 };
 
-export default function Page() {
-  // 商品IDにあたる検索条件
-  const params = { id: 1 };
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  // paramsをアンラップ(展開)
+  const id = Number(use(params).id);
 
   // 読込データを保持
   const [product, setProduct] = useState<ProductData>({
@@ -35,7 +35,7 @@ export default function Page() {
 
   useEffect(() => {
     const selectedProduct: ProductData = productsData.find(
-      (v) => v.id === params.id,
+      (v) => v.id === id,
     ) ?? {
       id: 0,
       name: "",
@@ -44,7 +44,7 @@ export default function Page() {
     };
     setProduct(selectedProduct);
     setData(inventoriesData);
-  }, []);
+  }, [id]);
 
   return (
     <>


### PR DESCRIPTION
このプルリクエストは、`app/inventory/products/[id]/page.tsx` 内の `Page` コンポーネントを更新し、**パラメーター処理を改善**し、`id` パラメーターの変更にコンポーネントが反応するようにします。最も重要な変更点として、Promise の解決に **`use` 関数を導入**し、**`params` 処理をリファクタリング**し、`useEffect` フック内の**依存配列を更新**しました。

---

### パラメーター処理の改善

* React の **`use` 関数**を追加し、`params` オブジェクトの Promise 解決を処理することで、解決された Promise から直接 `id` パラメーターを抽出できるようにしました。
    ([app/inventory/products/[id]/page.tsxL3-R3](diffhunk://#diff-a8ec604c8acf046235fe877cf65aac212c0e05028569e3fdbc9981e2e016e690L3-R3), [app/inventory/products/[id]/page.tsxL23-R25](diffhunk://#diff-a8ec604c8acf046235fe877cf65aac212c0e05028569e3fdbc9981e2e016e690L23-R25))

### React の状態とエフェクトの更新

* `useEffect` の依存配列に **`id` を含める**ように更新し、`id` パラメーターが変更されたときにエフェクトが再実行されるようにしました。
    ([app/inventory/products/[id]/page.tsxL47-R47](diffhunk://#diff-a8ec604c8acf046235fe877cf65aac212c0e05028569e3fdbc9981e2e016e690L47-R47))
* `useEffect` のロジックをリファクタリングし、以前の `params.id` 参照ではなく、**解決された `id` の値を使用**するようにしました。
    ([app/inventory/products/[id]/page.tsxL38-R38](diffhunk://#diff-a8ec604c8acf046235fe877cf65aac212c0e05028569e3fdbc9981e2e016e690L38-R38))