### PR TITLE
売上データを表示する

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Next.js: Debug",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "skipFiles": ["<node_internals>/**"],
+      "outputCapture": "std",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Next.js: Debug in Chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/app/inventory/import_sales/page.tsx
+++ b/app/inventory/import_sales/page.tsx
@@ -1,10 +1,23 @@
 "use client";
 
 import type { AlertColor } from "@mui/material";
-import { Alert, Box, Button, Snackbar, Typography } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Paper,
+  Snackbar,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
 import axios from "axios";
 import { MuiFileInput } from "mui-file-input";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Page() {
   const [open, setOpen] = useState(false);
@@ -15,6 +28,22 @@ export default function Page() {
     setSeverity(severity);
     setMessage(message);
   };
+  type MonthlySummary = {
+    monthly_date: string;
+    monthly_price: number;
+  };
+  const [monthlySummaries, setMonthlySummaries] = useState<MonthlySummary[]>(
+    [],
+  );
+
+  useEffect(() => {
+    axios
+      .get("http://localhost:8000/api/inventory/summary/")
+      .then((res) => res.data)
+      .then((data) => {
+        setMonthlySummaries(data);
+      });
+  }, []);
 
   const [fileSync, setFileSync] = useState<File | null>(null);
   const onChangeFileSync = (newFile: File | null) => {
@@ -61,6 +90,27 @@ export default function Page() {
         <Button variant="contained" onClick={doAddSync}>
           登録
         </Button>
+      </Box>
+      <Box m={2}>
+        <Typography variant="subtitle1">年月ごとの売上数集計</Typography>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>処理月</TableCell>
+                <TableCell>合計数量</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {monthlySummaries.map((data: MonthlySummary) => (
+                <TableRow key={data.monthly_date}>
+                  <TableCell>{data.monthly_date}</TableCell>
+                  <TableCell>{data.monthly_price}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Box>
     </Box>
   );


### PR DESCRIPTION
このプルリクエストでは、VS Code用のデバッグ設定を追加し、`import_sales` ページに月次売上サマリーを表示する機能を実装しました。これにより、開発体験が向上し、在庫データの可視化UIが改善されます。

### 開発環境の強化:

* `.vscode/launch.json` ファイルを新たに追加し、Node.js と Chrome 向けのデバッグ構成を定義しました。これは Next.js アプリケーションのデバッグに最適化されています。

### インベントリページの改善:

* `app/inventory/import_sales/page.tsx` において、Material-UI の追加コンポーネント（`Paper`、`Table`、`TableBody`、`TableCell`、`TableContainer`、`TableHead`、`TableRow`）および `useEffect` フックをインポートに追加しました。
* `MonthlySummary` 型と `useState` フックを導入し、月次売上サマリーの状態管理を追加しました。さらに、APIエンドポイント（`http://localhost:8000/api/inventory/summary/`）からデータを取得する `useEffect` フックを実装しました。
* 新たにテーブルを追加し、取得した月次売上データを「処理月」「合計数量」として動的に表示するようにしました。